### PR TITLE
Indentation same as other loop constructs

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -26,21 +26,20 @@ num_conflicts=0
 num_untracked=0
 while IFS='' read -r line || [[ -n "$line" ]]; do
   status=${line:0:2}
-  while [[ -n $status ]]
-  do
+  while [[ -n $status ]]; do
     case "$status" in
-#two fixed character matches, loop finished
+      #two fixed character matches, loop finished
       \#\#) branch_line="${line/\.\.\./^}"; break ;;
       \?\?) ((num_untracked++)); break ;;
       U?) ((num_conflicts++)); break;;
       ?U) ((num_conflicts++)); break;;
       DD) ((num_conflicts++)); break;;
       AA) ((num_conflicts++)); break;;
-#two character matches, first loop
+      #two character matches, first loop
       ?M) ((num_changed++)) ;;
       ?D) ((num_changed++)) ;;
       ?\ ) ;;
-#single character matches, second loop
+      #single character matches, second loop
       U) ((num_conflicts++)) ;;
       \ ) ;;
       *) ((num_staged++)) ;;


### PR DESCRIPTION
I think I understand the concept, very much inline with the table you get in the manpage for git status.

Maybe the loop construct should have the same indentation as the others and the comments indented as well. 
